### PR TITLE
Improve API helpers and add tests

### DIFF
--- a/test_imports.py
+++ b/test_imports.py
@@ -54,11 +54,11 @@ def main():
     
     # Print summary
     print(f"\nImport testing completed: {success_count}/{len(import_statements)} imports successful")
-    
     if success_count == len(import_statements):
-        print("\n✅ All imports working correctly!")
+        print("\nAll imports working correctly!")
     else:
-        print(f"\n⚠️ {len(import_statements) - success_count} imports still have issues")
+        failed = len(import_statements) - success_count
+        print(f"\nWARNING: {failed} imports failed.")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+from unittest import mock
+
+# Provide dummy modules for optional dependencies
+sys.modules.setdefault("pandas", mock.MagicMock())
+sys.modules.setdefault("requests", mock.MagicMock())
+
+import src.tools.api as api
+
+class TestAPIUtils(unittest.TestCase):
+    def test_get_api_headers_with_key(self):
+        with mock.patch.dict(os.environ, {"FINANCIAL_DATASETS_API_KEY": "abc"}):
+            self.assertEqual(api._get_api_headers(), {"X-API-KEY": "abc"})
+
+    def test_get_api_headers_without_key(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(api._get_api_headers(), {})
+
+    def test_get_prices_uses_session(self):
+        with mock.patch.object(api, "session") as mock_session:
+            mock_session.get.return_value.status_code = 200
+            mock_session.get.return_value.json.return_value = {"ticker": "AAPL", "prices": []}
+            with mock.patch.dict(os.environ, {"FINANCIAL_DATASETS_API_KEY": "k"}):
+                api.get_prices("AAPL", "2020-01-01", "2020-02-01")
+            mock_session.get.assert_called_once()
+            args, kwargs = mock_session.get.call_args
+            self.assertIn("timeout", kwargs)
+            self.assertEqual(kwargs["headers"], {"X-API-KEY": "k"})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor `src.tools.api` to use a shared `requests` session
- add `_get_api_headers` helper for cleaner API key handling
- include request timeouts for stability
- clean up `test_imports.py`
- create new unit tests for API helpers

## Testing
- `python -m unittest tests.test_api -v`

## Summary by Sourcery

Refactor API helpers to use a shared session, centralize header handling, add request timeouts, clean up import testing output, and introduce unit tests for API utilities

Enhancements:
- Use a shared requests.Session with a default timeout across API helper functions
- Introduce a centralized _get_api_headers helper to streamline API key handling
- Clean up output formatting in test_imports.py

Tests:
- Add unit tests for API helper functions covering header generation and session usage in test_api.py