### PR TITLE
Increase test coverage for utility modules

### DIFF
--- a/tests/test_api_market_cap.py
+++ b/tests/test_api_market_cap.py
@@ -1,0 +1,22 @@
+import sys
+import types
+import unittest
+from unittest import mock
+
+# Provide dummy modules for optional dependencies
+sys.modules.setdefault("pandas", mock.MagicMock())
+sys.modules.setdefault("requests", mock.MagicMock())
+
+import src.tools.api as api
+
+
+class TestMarketCap(unittest.TestCase):
+    def test_get_market_cap(self):
+        dummy_metric = types.SimpleNamespace(market_cap=123.0)
+        with mock.patch.object(api, "get_financial_metrics", return_value=[dummy_metric]):
+            result = api.get_market_cap("AAPL", "2024-01-01")
+        self.assertEqual(result, 123.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,34 @@
+import unittest
+
+from src.data.cache import Cache
+
+
+class TestCache(unittest.TestCase):
+    def test_merge_data_no_existing(self):
+        cache = Cache()
+        new_data = [{"id": 1}, {"id": 2}]
+        merged = cache._merge_data(None, new_data, "id")
+        self.assertEqual(merged, new_data)
+
+    def test_merge_data_with_duplicates(self):
+        cache = Cache()
+        existing = [{"id": 1}, {"id": 2}]
+        new_data = [{"id": 2}, {"id": 3}]
+        merged = cache._merge_data(existing, new_data, "id")
+        self.assertEqual(merged, [{"id": 1}, {"id": 2}, {"id": 3}])
+
+    def test_set_get_prices_merges(self):
+        cache = Cache()
+        cache.set_prices("AAPL", [{"time": "2024-01-01", "p": 1}])
+        # Duplicate date should not be added twice
+        cache.set_prices("AAPL", [
+            {"time": "2024-01-01", "p": 1},
+            {"time": "2024-01-02", "p": 2},
+        ])
+        prices = cache.get_prices("AAPL")
+        self.assertEqual(len(prices), 2)
+        self.assertEqual(prices[1]["time"], "2024-01-02")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,62 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+class TestDisplayUtils(unittest.TestCase):
+    def setUp(self):
+        # Create fake colorama module
+        fore = types.SimpleNamespace(GREEN='GREEN', RED='RED', YELLOW='YELLOW', WHITE='WHITE', CYAN='CYAN', BLUE='BLUE')
+        style = types.SimpleNamespace(BRIGHT='BRIGHT', RESET_ALL='RESET')
+        fake_colorama = types.SimpleNamespace(Fore=fore, Style=style)
+        fake_tabulate = lambda *args, **kwargs: 'table'
+        fake_tabulate_mod = types.SimpleNamespace(tabulate=fake_tabulate)
+        fake_analysts = types.SimpleNamespace(ANALYST_ORDER=[('Ben Graham', 'bg'), ('Bill Ackman', 'ba')])
+        self.patches = [
+            mock.patch.dict(sys.modules, {
+                'colorama': fake_colorama,
+                'tabulate': fake_tabulate_mod,
+                'src.utils.analysts': fake_analysts,
+            })
+        ]
+        for p in self.patches:
+            p.start()
+        self.display = importlib.import_module('src.utils.display')
+
+    def tearDown(self):
+        for p in self.patches:
+            p.stop()
+        if 'src.utils.display' in sys.modules:
+            del sys.modules['src.utils.display']
+
+    def test_sort_agent_signals(self):
+        signals = [
+            ['Bill Ackman', '', '', ''],
+            ['Ben Graham', '', '', ''],
+        ]
+        sorted_signals = self.display.sort_agent_signals(signals)
+        self.assertEqual(sorted_signals[0][0], 'Ben Graham')
+
+    def test_format_backtest_row(self):
+        row = self.display.format_backtest_row(
+            '2024-01-01', 'AAPL', 'BUY', 10, 1.0, 10, 10.0, 1, 0, 0
+        )
+        self.assertEqual(row[0], '2024-01-01')
+        self.assertIn('AAPL', row[1])
+        self.assertIn('BUY', row[2])
+
+    def test_format_backtest_row_summary(self):
+        row = self.display.format_backtest_row(
+            '2024-01-01', '', 'HOLD', 0, 0, 0, 0, 0, 0, 0,
+            is_summary=True, total_value=10, return_pct=1.0,
+            cash_balance=5.0, total_position_value=5.0,
+            sharpe_ratio=1.1, sortino_ratio=1.0, max_drawdown=0.5
+        )
+        self.assertIn('PORTFOLIO SUMMARY', row[1])
+        self.assertEqual(row[-1], 'RED0.50%RESET')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,49 @@
+import sys
+import types
+import unittest
+from typing import Literal
+from unittest import mock
+
+# Provide dummy modules for rich which is required by progress
+sys.modules.setdefault("rich.console", mock.MagicMock())
+sys.modules.setdefault("rich.live", mock.MagicMock())
+sys.modules.setdefault("rich.table", mock.MagicMock())
+sys.modules.setdefault("rich.style", mock.MagicMock())
+sys.modules.setdefault("rich.text", mock.MagicMock())
+
+from src.utils.llm import create_default_response, extract_json_from_deepseek_response
+
+
+class DummyModel:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+DummyModel.model_fields = {
+    'name': types.SimpleNamespace(annotation=str),
+    'value': types.SimpleNamespace(annotation=float),
+    'count': types.SimpleNamespace(annotation=int),
+    'data': types.SimpleNamespace(annotation=dict),
+    'label': types.SimpleNamespace(annotation=Literal['A', 'B'])
+}
+
+
+class TestLLMUtils(unittest.TestCase):
+    def test_create_default_response(self):
+        result = create_default_response(DummyModel)
+        self.assertEqual(result.name, "Error in analysis, using default")
+        self.assertEqual(result.value, 0.0)
+        self.assertEqual(result.count, 0)
+        self.assertIsNone(result.data)
+        self.assertEqual(result.label, 'A')
+
+    def test_extract_json_success(self):
+        content = "prefix```json\n{\"a\": 1}\n```suffix"
+        self.assertEqual(extract_json_from_deepseek_response(content), {"a": 1})
+
+    def test_extract_json_failure(self):
+        self.assertIsNone(extract_json_from_deepseek_response("no json here"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for cache behavior
- test llm helpers without external dependencies
- cover display formatting with mocked colorama
- validate market cap helper

## Testing
- `python -m unittest discover -s tests`

## Summary by Sourcery

Increase test coverage for utility modules by adding focused unit tests for display, LLM, cache, and market cap functions.

Tests:
- Add unit tests for display utilities including signal sorting and backtest row formatting.
- Add unit tests for LLM helpers covering default response creation and JSON extraction.
- Add unit tests for cache merging behavior to ensure correct deduplication of price data.
- Add unit test for market cap helper to validate API-based market cap retrieval.