### PR TITLE
[Test] Expand coverage with additional edge and security tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,7 @@ sys.modules.setdefault("requests", mock.MagicMock())
 
 import src.tools.api as api
 
+
 class TestAPIUtils(unittest.TestCase):
     def test_get_api_headers_with_key(self):
         with mock.patch.dict(os.environ, {"FINANCIAL_DATASETS_API_KEY": "abc"}):
@@ -28,6 +29,7 @@ class TestAPIUtils(unittest.TestCase):
             args, kwargs = mock_session.get.call_args
             self.assertIn("timeout", kwargs)
             self.assertEqual(kwargs["headers"], {"X-API-KEY": "k"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -21,13 +21,30 @@ class TestCache(unittest.TestCase):
         cache = Cache()
         cache.set_prices("AAPL", [{"time": "2024-01-01", "p": 1}])
         # Duplicate date should not be added twice
-        cache.set_prices("AAPL", [
-            {"time": "2024-01-01", "p": 1},
-            {"time": "2024-01-02", "p": 2},
-        ])
+        cache.set_prices(
+            "AAPL",
+            [
+                {"time": "2024-01-01", "p": 1},
+                {"time": "2024-01-02", "p": 2},
+            ],
+        )
         prices = cache.get_prices("AAPL")
         self.assertEqual(len(prices), 2)
         self.assertEqual(prices[1]["time"], "2024-01-02")
+
+    def test_merge_data_empty_new(self):
+        cache = Cache()
+        existing = [{"id": 1}]
+        merged = cache._merge_data(existing, [], "id")
+        self.assertEqual(merged, existing)
+
+    def test_reset_clears_all(self):
+        cache = Cache()
+        cache.set_prices("AAPL", [{"time": "2024-01-01", "p": 1}])
+        cache.set_financial_metrics("AAPL", [{"report_period": "2024-01-01"}])
+        cache.reset()
+        self.assertIsNone(cache.get_prices("AAPL"))
+        self.assertIsNone(cache.get_financial_metrics("AAPL"))
 
 
 if __name__ == "__main__":

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -8,55 +8,55 @@ from unittest import mock
 class TestDisplayUtils(unittest.TestCase):
     def setUp(self):
         # Create fake colorama module
-        fore = types.SimpleNamespace(GREEN='GREEN', RED='RED', YELLOW='YELLOW', WHITE='WHITE', CYAN='CYAN', BLUE='BLUE')
-        style = types.SimpleNamespace(BRIGHT='BRIGHT', RESET_ALL='RESET')
+        fore = types.SimpleNamespace(GREEN="GREEN", RED="RED", YELLOW="YELLOW", WHITE="WHITE", CYAN="CYAN", BLUE="BLUE")
+        style = types.SimpleNamespace(BRIGHT="BRIGHT", RESET_ALL="RESET")
         fake_colorama = types.SimpleNamespace(Fore=fore, Style=style)
-        fake_tabulate = lambda *args, **kwargs: 'table'
+        fake_tabulate = lambda *args, **kwargs: "table"
         fake_tabulate_mod = types.SimpleNamespace(tabulate=fake_tabulate)
-        fake_analysts = types.SimpleNamespace(ANALYST_ORDER=[('Ben Graham', 'bg'), ('Bill Ackman', 'ba')])
+        fake_analysts = types.SimpleNamespace(ANALYST_ORDER=[("Ben Graham", "bg"), ("Bill Ackman", "ba")])
         self.patches = [
-            mock.patch.dict(sys.modules, {
-                'colorama': fake_colorama,
-                'tabulate': fake_tabulate_mod,
-                'src.utils.analysts': fake_analysts,
-            })
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "colorama": fake_colorama,
+                    "tabulate": fake_tabulate_mod,
+                    "src.utils.analysts": fake_analysts,
+                },
+            )
         ]
         for p in self.patches:
             p.start()
-        self.display = importlib.import_module('src.utils.display')
+        self.display = importlib.import_module("src.utils.display")
 
     def tearDown(self):
         for p in self.patches:
             p.stop()
-        if 'src.utils.display' in sys.modules:
-            del sys.modules['src.utils.display']
+        if "src.utils.display" in sys.modules:
+            del sys.modules["src.utils.display"]
 
     def test_sort_agent_signals(self):
         signals = [
-            ['Bill Ackman', '', '', ''],
-            ['Ben Graham', '', '', ''],
+            ["Bill Ackman", "", "", ""],
+            ["Ben Graham", "", "", ""],
         ]
         sorted_signals = self.display.sort_agent_signals(signals)
-        self.assertEqual(sorted_signals[0][0], 'Ben Graham')
+        self.assertEqual(sorted_signals[0][0], "Ben Graham")
 
     def test_format_backtest_row(self):
-        row = self.display.format_backtest_row(
-            '2024-01-01', 'AAPL', 'BUY', 10, 1.0, 10, 10.0, 1, 0, 0
-        )
-        self.assertEqual(row[0], '2024-01-01')
-        self.assertIn('AAPL', row[1])
-        self.assertIn('BUY', row[2])
+        row = self.display.format_backtest_row("2024-01-01", "AAPL", "BUY", 10, 1.0, 10, 10.0, 1, 0, 0)
+        self.assertEqual(row[0], "2024-01-01")
+        self.assertIn("AAPL", row[1])
+        self.assertIn("BUY", row[2])
 
     def test_format_backtest_row_summary(self):
-        row = self.display.format_backtest_row(
-            '2024-01-01', '', 'HOLD', 0, 0, 0, 0, 0, 0, 0,
-            is_summary=True, total_value=10, return_pct=1.0,
-            cash_balance=5.0, total_position_value=5.0,
-            sharpe_ratio=1.1, sortino_ratio=1.0, max_drawdown=0.5
-        )
-        self.assertIn('PORTFOLIO SUMMARY', row[1])
-        self.assertEqual(row[-1], 'RED0.50%RESET')
+        row = self.display.format_backtest_row("2024-01-01", "", "HOLD", 0, 0, 0, 0, 0, 0, 0, is_summary=True, total_value=10, return_pct=1.0, cash_balance=5.0, total_position_value=5.0, sharpe_ratio=1.1, sortino_ratio=1.0, max_drawdown=0.5)
+        self.assertIn("PORTFOLIO SUMMARY", row[1])
+        self.assertEqual(row[-1], "RED0.50%RESET")
+
+    def test_format_backtest_row_negative_return(self):
+        row = self.display.format_backtest_row("2024-01-02", "", "SELL", 0, 0, 0, 0, 0, 0, 0, is_summary=True, total_value=10, return_pct=-1.0, cash_balance=5.0, total_position_value=5.0, sharpe_ratio=0.5, sortino_ratio=0.4, max_drawdown=0.2)
+        self.assertIn("RED-1.00%RESET", row[9])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -19,13 +19,8 @@ class DummyModel:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-DummyModel.model_fields = {
-    'name': types.SimpleNamespace(annotation=str),
-    'value': types.SimpleNamespace(annotation=float),
-    'count': types.SimpleNamespace(annotation=int),
-    'data': types.SimpleNamespace(annotation=dict),
-    'label': types.SimpleNamespace(annotation=Literal['A', 'B'])
-}
+
+DummyModel.model_fields = {"name": types.SimpleNamespace(annotation=str), "value": types.SimpleNamespace(annotation=float), "count": types.SimpleNamespace(annotation=int), "data": types.SimpleNamespace(annotation=dict), "label": types.SimpleNamespace(annotation=Literal["A", "B"])}
 
 
 class TestLLMUtils(unittest.TestCase):
@@ -35,14 +30,45 @@ class TestLLMUtils(unittest.TestCase):
         self.assertEqual(result.value, 0.0)
         self.assertEqual(result.count, 0)
         self.assertIsNone(result.data)
-        self.assertEqual(result.label, 'A')
+        self.assertEqual(result.label, "A")
 
     def test_extract_json_success(self):
-        content = "prefix```json\n{\"a\": 1}\n```suffix"
+        content = 'prefix```json\n{"a": 1}\n```suffix'
         self.assertEqual(extract_json_from_deepseek_response(content), {"a": 1})
 
     def test_extract_json_failure(self):
         self.assertIsNone(extract_json_from_deepseek_response("no json here"))
+
+    def test_extract_json_with_script(self):
+        content = 'prefix```json\n{"a": "<script>1</script>"}\n```suffix'
+        result = extract_json_from_deepseek_response(content)
+        self.assertEqual(result, {"a": "<script>1</script>"})
+
+    def test_call_llm_default_factory(self):
+        from src.utils import llm as llm_module
+
+        class FakeLLM:
+            def with_structured_output(self, *_, **__):
+                return self
+
+            def invoke(self, *_):
+                raise RuntimeError("boom")
+
+        fake_models_mod = types.SimpleNamespace(
+            get_model_info=lambda name: types.SimpleNamespace(has_json_mode=lambda: True),
+            get_model=lambda *args, **kwargs: FakeLLM(),
+        )
+        with mock.patch.dict(sys.modules, {"src.llm.models": fake_models_mod}), mock.patch.object(llm_module.progress, "update_status"):
+            factory_called = {}
+
+            def factory():
+                factory_called["called"] = True
+                return DummyModel(name="d", value=1.0, count=1, data={}, label="A")
+
+            result = llm_module.call_llm("prompt", "model", "provider", DummyModel, default_factory=factory)
+
+        self.assertTrue(factory_called.get("called"))
+        self.assertEqual(result.name, "d")
 
 
 if __name__ == "__main__":

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+class TestAgentProgress(unittest.TestCase):
+    def setUp(self):
+        fake_console = mock.MagicMock()
+        fake_live_instance = mock.MagicMock()
+        fake_live = mock.MagicMock(return_value=fake_live_instance)
+        fake_table = mock.MagicMock()
+        fake_style = types.SimpleNamespace()
+        fake_text = mock.MagicMock()
+        self.patcher = mock.patch.dict(
+            sys.modules,
+            {
+                "rich.console": types.SimpleNamespace(Console=lambda: fake_console),
+                "rich.live": types.SimpleNamespace(Live=fake_live),
+                "rich.table": types.SimpleNamespace(Table=lambda **_: fake_table),
+                "rich.style": types.SimpleNamespace(Style=lambda **_: fake_style),
+                "rich.text": types.SimpleNamespace(Text=lambda: fake_text),
+            },
+        )
+        self.patcher.start()
+        self.progress_mod = importlib.import_module("src.utils.progress")
+        self.progress = self.progress_mod.AgentProgress()
+
+    def tearDown(self):
+        self.patcher.stop()
+        if "src.utils.progress" in sys.modules:
+            del sys.modules["src.utils.progress"]
+
+    def test_update_and_reset_status(self):
+        self.progress.update_status("agent_a", status="running")
+        self.assertIn("agent_a", self.progress.agent_status)
+        self.assertEqual(self.progress.agent_status["agent_a"]["status"], "running")
+        self.progress.start()
+        self.assertTrue(self.progress.started)
+        self.progress.stop()
+        self.assertFalse(self.progress.started)


### PR DESCRIPTION
## Summary
- extend cache tests for empty merges and reset logic
- check display formatting for negative returns
- ensure LLMM helper handles failures using a default factory
- add regression tests for progress tracking utilities
- enhance llm JSON extraction test

## Testing Done
- `python -m unittest discover tests -v`

## Summary by Sourcery

Expand unit test coverage by adding edge case, fallback, and security tests across display, LLM, cache, and progress utilities.

Enhancements:
- Normalize string quoting and formatting in test modules

Tests:
- Add test for negative return formatting in display utils
- Add JSON extraction test preserving script tags in LLM utils
- Add test for default factory fallback on LLM invocation failure
- Add cache tests for empty data merge handling and reset behavior
- Add progress tracking tests for AgentProgress status updates, start, and stop