### PR TITLE
[Test] Validate sort_agent_signals fallback

### DIFF
--- a/src/utils/analysts.py
+++ b/src/utils/analysts.py
@@ -74,6 +74,10 @@ ANALYST_CONFIG = {
 # Derive ANALYST_ORDER from ANALYST_CONFIG for backwards compatibility
 ANALYST_ORDER = [(config["display_name"], key) for key, config in sorted(ANALYST_CONFIG.items(), key=lambda x: x[1]["order"])]
 
+# Precompute a mapping for quick lookups when sorting analyst output
+ANALYST_ORDER_MAP = {display: idx for idx, (display, _) in enumerate(ANALYST_ORDER)}
+ANALYST_ORDER_MAP["Risk Management"] = len(ANALYST_ORDER)
+
 
 def get_analyst_nodes():
     """Get the mapping of analyst keys to their (node_name, agent_func) tuples."""

--- a/src/utils/display.py
+++ b/src/utils/display.py
@@ -1,17 +1,13 @@
 from colorama import Fore, Style
 from tabulate import tabulate
-from .analysts import ANALYST_ORDER
+from .analysts import ANALYST_ORDER, ANALYST_ORDER_MAP
 import os
 import json
 
 
 def sort_agent_signals(signals):
     """Sort agent signals in a consistent order."""
-    # Create order mapping from ANALYST_ORDER
-    analyst_order = {display: idx for idx, (display, _) in enumerate(ANALYST_ORDER)}
-    analyst_order["Risk Management"] = len(ANALYST_ORDER)  # Add Risk Management at the end
-
-    return sorted(signals, key=lambda x: analyst_order.get(x[0], 999))
+    return sorted(signals, key=lambda x: ANALYST_ORDER_MAP.get(x[0], 999))
 
 
 def print_trading_output(result: dict) -> None:
@@ -36,7 +32,7 @@ def print_trading_output(result: dict) -> None:
         for agent, signals in result.get("analyst_signals", {}).items():
             if ticker not in signals:
                 continue
-                
+
             # Skip Risk Management agent in the signals section
             if agent == "risk_management_agent":
                 continue
@@ -51,12 +47,12 @@ def print_trading_output(result: dict) -> None:
                 "BEARISH": Fore.RED,
                 "NEUTRAL": Fore.YELLOW,
             }.get(signal_type, Fore.WHITE)
-            
+
             # Get reasoning if available
             reasoning_str = ""
             if "reasoning" in signal and signal["reasoning"]:
                 reasoning = signal["reasoning"]
-                
+
                 # Handle different types of reasoning (string, dict, etc.)
                 if isinstance(reasoning, str):
                     reasoning_str = reasoning
@@ -66,7 +62,7 @@ def print_trading_output(result: dict) -> None:
                 else:
                     # Convert any other type to string
                     reasoning_str = str(reasoning)
-                
+
                 # Wrap long reasoning text to make it more readable
                 wrapped_reasoning = ""
                 current_line = ""
@@ -83,7 +79,7 @@ def print_trading_output(result: dict) -> None:
                             current_line = word
                 if current_line:
                     wrapped_reasoning += current_line
-                
+
                 reasoning_str = wrapped_reasoning
 
             table_data.append(
@@ -147,21 +143,21 @@ def print_trading_output(result: dict) -> None:
             ],
             ["Reasoning", f"{Fore.WHITE}{wrapped_reasoning}{Style.RESET_ALL}"],
         ]
-        
+
         print(f"\n{Fore.WHITE}{Style.BRIGHT}TRADING DECISION:{Style.RESET_ALL} [{Fore.CYAN}{ticker}{Style.RESET_ALL}]")
         print(tabulate(decision_data, tablefmt="grid", colalign=("left", "left")))
 
     # Print Portfolio Summary
     print(f"\n{Fore.WHITE}{Style.BRIGHT}PORTFOLIO SUMMARY:{Style.RESET_ALL}")
     portfolio_data = []
-    
+
     # Extract portfolio manager reasoning (common for all tickers)
     portfolio_manager_reasoning = None
     for ticker, decision in decisions.items():
         if decision.get("reasoning"):
             portfolio_manager_reasoning = decision.get("reasoning")
             break
-            
+
     for ticker, decision in decisions.items():
         action = decision.get("action", "").upper()
         action_color = {
@@ -181,7 +177,7 @@ def print_trading_output(result: dict) -> None:
         )
 
     headers = [f"{Fore.WHITE}Ticker", "Action", "Quantity", "Confidence"]
-    
+
     # Print the portfolio summary table
     print(
         tabulate(
@@ -191,7 +187,7 @@ def print_trading_output(result: dict) -> None:
             colalign=("left", "center", "right", "right"),
         )
     )
-    
+
     # Print Portfolio Manager's reasoning if available
     if portfolio_manager_reasoning:
         # Handle different types of reasoning (string, dict, etc.)
@@ -204,7 +200,7 @@ def print_trading_output(result: dict) -> None:
         else:
             # Convert any other type to string
             reasoning_str = str(portfolio_manager_reasoning)
-            
+
         # Wrap long reasoning text to make it more readable
         wrapped_reasoning = ""
         current_line = ""
@@ -221,7 +217,7 @@ def print_trading_output(result: dict) -> None:
                     current_line = word
         if current_line:
             wrapped_reasoning += current_line
-            
+
         print(f"\n{Fore.WHITE}{Style.BRIGHT}Portfolio Strategy:{Style.RESET_ALL}")
         print(f"{Fore.CYAN}{wrapped_reasoning}{Style.RESET_ALL}")
 
@@ -241,7 +237,6 @@ def print_backtest_results(table_rows: list) -> None:
         else:
             ticker_rows.append(row)
 
-    
     # Display latest portfolio summary
     if summary_rows:
         latest_summary = summary_rows[-1]
@@ -256,7 +251,7 @@ def print_backtest_results(table_rows: list) -> None:
         print(f"Total Position Value: {Fore.YELLOW}${float(position_str):,.2f}{Style.RESET_ALL}")
         print(f"Total Value: {Fore.WHITE}${float(total_str):,.2f}{Style.RESET_ALL}")
         print(f"Return: {latest_summary[9]}")
-        
+
         # Display performance metrics if available
         if latest_summary[10]:  # Sharpe ratio
             print(f"Sharpe Ratio: {latest_summary[10]}")

--- a/tests/test_analysts.py
+++ b/tests/test_analysts.py
@@ -1,0 +1,15 @@
+import unittest
+from importlib import reload
+
+
+class TestAnalystOrderMap(unittest.TestCase):
+    def test_order_map_matches_order(self):
+        mod = reload(__import__("src.utils.analysts", fromlist=[""]))
+        order_map = mod.ANALYST_ORDER_MAP
+        for idx, (display, _) in enumerate(mod.ANALYST_ORDER):
+            self.assertEqual(order_map[display], idx)
+        self.assertEqual(order_map["Risk Management"], len(mod.ANALYST_ORDER))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -13,7 +13,10 @@ class TestDisplayUtils(unittest.TestCase):
         fake_colorama = types.SimpleNamespace(Fore=fore, Style=style)
         fake_tabulate = lambda *args, **kwargs: "table"
         fake_tabulate_mod = types.SimpleNamespace(tabulate=fake_tabulate)
-        fake_analysts = types.SimpleNamespace(ANALYST_ORDER=[("Ben Graham", "bg"), ("Bill Ackman", "ba")])
+        fake_analysts = types.SimpleNamespace(
+            ANALYST_ORDER=[("Ben Graham", "bg"), ("Bill Ackman", "ba")],
+            ANALYST_ORDER_MAP={"Ben Graham": 0, "Bill Ackman": 1, "Risk Management": 2},
+        )
         self.patches = [
             mock.patch.dict(
                 sys.modules,
@@ -41,6 +44,17 @@ class TestDisplayUtils(unittest.TestCase):
         ]
         sorted_signals = self.display.sort_agent_signals(signals)
         self.assertEqual(sorted_signals[0][0], "Ben Graham")
+
+    def test_sort_agent_signals_unknown(self):
+        signals = [
+            ["Unknown Analyst", "", "", ""],
+            ["Ben Graham", "", "", ""],
+        ]
+        sorted_signals = self.display.sort_agent_signals(signals)
+        # Known analyst should come first
+        self.assertEqual(sorted_signals[0][0], "Ben Graham")
+        # Unknown analyst falls back to end
+        self.assertEqual(sorted_signals[1][0], "Unknown Analyst")
 
     def test_format_backtest_row(self):
         row = self.display.format_backtest_row("2024-01-01", "AAPL", "BUY", 10, 1.0, 10, 10.0, 1, 0, 0)


### PR DESCRIPTION
## Summary
- verify sort_agent_signals handles unknown analysts

## Testing Done
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_682b9e850bb8833293b13472561d468a

## Summary by Sourcery

Leverage a precomputed ANALYST_ORDER_MAP to sort agent signals with fallback for unknown analysts, update related code in display utilities, and extend unit tests to cover the new mapping and fallback behavior.

Bug Fixes:
- Ensure sort_agent_signals places unknown analysts at the end using a default fallback index

Enhancements:
- Replace manual sorting logic in sort_agent_signals with a lookup into ANALYST_ORDER_MAP
- Remove obsolete mapping code and clean up whitespace in display.print_trading_output and print_backtest_results

Tests:
- Add test for sort_agent_signals to verify unknown analysts are sorted to the end
- Add test to validate ANALYST_ORDER_MAP matches the order defined in ANALYST_ORDER

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved sorting of analyst outputs by introducing a more efficient internal mapping for analyst order.
- **Bug Fixes**
  - Ensured unknown analysts are consistently placed at the end when sorting outputs.
- **Tests**
  - Added tests to verify the accuracy of analyst order mapping and correct sorting behavior for unknown analysts.
- **Style**
  - Minor cleanup of whitespace in display output functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->